### PR TITLE
Add basic VegaEngine cache + bugfix

### DIFF
--- a/plot/js-lib/vega.js
+++ b/plot/js-lib/vega.js
@@ -33712,7 +33712,7 @@ function ContextFork(ctx) {
 }
 
 function readDataLocal(uri) {
-  var match = uri.match(/.*\/data\/(.*)\.json/);
+  var match = uri.match(/.*data\/(.*)\.json/);
   var name = match[1];
   var data = readFile('plot/data/' + name + '.json');
   return data


### PR DESCRIPTION
SVG are now < 0.1 seconds per example on average.